### PR TITLE
Fix distutils deprecation

### DIFF
--- a/pandas_datareader/compat/__init__.py
+++ b/pandas_datareader/compat/__init__.py
@@ -2,6 +2,11 @@ from io import StringIO
 import sys
 from urllib.error import HTTPError
 
+try:  # Python <3.13 compatibility
+    from packaging.version import Version as LooseVersion
+except Exception:  # pragma: no cover - fallback for very old installs
+    from distutils.version import LooseVersion
+
 from pandas.api.types import is_list_like, is_number
 from pandas.io import common as com
 from pandas.testing import assert_frame_equal

--- a/pandas_datareader/tests/test_compat_version.py
+++ b/pandas_datareader/tests/test_compat_version.py
@@ -1,0 +1,9 @@
+import pytest
+
+from pandas_datareader.compat import LooseVersion
+
+
+def test_loose_version_comparison():
+    assert LooseVersion("1.0") < LooseVersion("2.0")
+    assert LooseVersion("2.0") > LooseVersion("1.0")
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pytest-xdist
 pytest-cov
 wrapt
 flake8-pyproject
+packaging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 lxml
 pandas>=1.5.3
 requests>=2.19.0
+packaging
+


### PR DESCRIPTION
## Summary
- remove distutils warning by using `packaging.version`
- include `packaging` in dependencies
- add basic test for LooseVersion alias

## Testing
- `python -m pytest pandas_datareader/tests/test_compat_version.py -q` *(fails: No module named pytest)*